### PR TITLE
fixed deprecated cgi.parse_qs calls

### DIFF
--- a/cyclone/auth.py
+++ b/cyclone/auth.py
@@ -51,7 +51,6 @@ from cyclone import escape, httpclient
 
 import base64
 import binascii
-import cgi
 import functools
 import hashlib
 import hmac
@@ -870,7 +869,7 @@ def _oauth_escape(val):
 
 
 def _oauth_parse_response(body):
-    p = cgi.parse_qs(body, keep_blank_values=False)
+    p = urlparse.parse_qs(body, keep_blank_values=False)
     token = dict(key=p["oauth_token"][0], secret=p["oauth_token_secret"][0])
 
     # Add the extra parameters the Provider included to the token

--- a/cyclone/httpserver.py
+++ b/cyclone/httpserver.py
@@ -18,7 +18,6 @@
 from twisted.python import log
 from twisted.protocols import basic
 from twisted.internet import defer, protocol
-import cgi
 import errno
 import functools
 import time
@@ -146,7 +145,7 @@ class HTTPConnection(basic.LineReceiver):
         content_type = self._request.headers.get("Content-Type", "")
         if self._request.method == "POST":
             if content_type.startswith("application/x-www-form-urlencoded"):
-                arguments = cgi.parse_qs(self._request.body)
+                arguments = urlparse.parse_qs(self._request.body)
                 for name, values in arguments.iteritems():
                     values = [v for v in values if v]
                     if values:
@@ -236,7 +235,7 @@ class HTTPRequest(object):
         scheme, netloc, path, query, fragment = urlparse.urlsplit(uri)
         self.path = path
         self.query = query
-        arguments = cgi.parse_qs(query)
+        arguments = urlparse.parse_qs(query)
         self.arguments = {}
         for name, values in arguments.iteritems():
             values = [v for v in values if v]


### PR DESCRIPTION
hi,

the function cgi.parse_qs() is now deprecated in favor of the equivalent urlparse function.

this very trivial commit fixes the problem.

bye,
flavio
