### PR TITLE
Content-Length 0 fails to set request handler callback

### DIFF
--- a/cyclone/httpserver.py
+++ b/cyclone/httpserver.py
@@ -143,9 +143,8 @@ class HTTPConnection(basic.LineReceiver):
                 connection=self, method=method, uri=uri, version=version,
                 headers=headers, remote_ip=self.transport.getPeer().host)
 
-            content_length = headers.get("Content-Length")
+            content_length = int(headers.get("Content-Length", 0))
             if content_length:
-                content_length = int(content_length)
                 if headers.get("Expect") == "100-continue":
                     self.transport.write("HTTP/1.1 100 (Continue)\r\n\r\n")
                 self.content_length = content_length


### PR DESCRIPTION
If Content-Length is 0, it gets returned as str(0), which _incorrectly_ matches the `if content_length` check.  Changed the Content-Length lookup to int'ify the result.

Gabe
