### PR TITLE
websocket handler regression on self._transforms

### DIFF
--- a/cyclone/websocket.py
+++ b/cyclone/websocket.py
@@ -56,6 +56,7 @@ class WebSocketHandler(cyclone.web.RequestHandler):
         self.ws_protocol.handleRawData(data)
 
     def _execute(self, transforms, *args, **kwargs):
+        self._transforms = transforms or list()
         try:
             assert self.request.headers["Upgrade"].lower() == "websocket"
             #assert self.request.headers["Connection"].lower() == "upgrade"


### PR DESCRIPTION
web socket connections fails with an 'Unhandled Error'

```
  File "/Library/Python/2.7/site-packages/cyclone-1.0_rc4-py2.7.egg/cyclone/web.py", line 578, in flush
    for transform in self._transforms:
exceptions.TypeError: 'NoneType' object is not iterable
```

RequestHandler constructor says

self._transforms = None  # will be set in _execute

WebSocketHandler _execute method don't set the self._transforms variable.

proposed fix is to set the self._transform ivar in the WebSocketHandler's _execute method
