### PR TITLE
passing kwargs to websocket constructor

### DIFF
--- a/cyclone/websocket.py
+++ b/cyclone/websocket.py
@@ -29,8 +29,9 @@ class _NotEnoughFrame(Exception):
 
 
 class WebSocketHandler(cyclone.web.RequestHandler):
-    def __init__(self, application, request):
-        cyclone.web.RequestHandler.__init__(self, application, request)
+    def __init__(self, application, request, **kwargs):
+        cyclone.web.RequestHandler.__init__(self, application, request,
+                                            **kwargs)
         self.application = application
         self.request = request
         self.transport = request.connection.transport


### PR DESCRIPTION
hi,

i think it would be more correct to pass a kwargs argument to websocket's **init** to customize the underlying handler and for coherence with the rest of the codebase (and 'cause i need that feature for my project :) )

attached the trivial patch

bye
