### PR TITLE
Backport fix for tornado issue #489 from tornado

### DIFF
--- a/cyclone/httputil.py
+++ b/cyclone/httputil.py
@@ -212,11 +212,11 @@ def parse_multipart_form_data(boundary, data, arguments, files):
     # in the wild.
     if boundary.startswith(b('"')) and boundary.endswith(b('"')):
         boundary = boundary[1:-1]
-    if data.endswith(b("\r\n")):
-        footer_length = len(boundary) + 6
-    else:
-        footer_length = len(boundary) + 4
-    parts = data[:-footer_length].split(b("--") + boundary + b("\r\n"))
+    final_boundary_index = data.rfind(b("--") + boundary + b("--"))
+    if final_boundary_index == -1:
+        log.msg("Invalid multipart/form-data: no final boundary")
+        return
+    parts = data[:final_boundary_index].split(b("--") + boundary + b("\r\n"))
     for part in parts:
         if not part:
             continue


### PR DESCRIPTION
I've been trying to get a file POST request working from AFNetworking (an iOS library), but the `handler.request.files` was always turning out to be empty. With a little bit of pdb based debugging, I managed to narrow this down to `cyclone.httputil.parse_multipart_form_data`. Eventually, I found out that the same issue had been reported on tornado a couple of weeks ago and had been fixed. This is a backport of that fix.

The tornado [issue](https://github.com/facebook/tornado/issues/489) has more details.

Thanks
