### PR TITLE
WebSocketProtocol17.sendMessage vs unicode

### DIFF
--- a/cyclone/websocket.py
+++ b/cyclone/websocket.py
@@ -247,7 +247,8 @@ class WebSocketProtocol17(WebSocketProtocol):
             return str(payload)
 
     def sendMessage(self, message, code=0x81):
-        message = unicode(message, "utf-8")
+        if isinstance(message, unicode):
+            message = message.encode('utf8')
         length = len(message)
         newFrame = []
         newFrame.append(code)
@@ -261,7 +262,7 @@ class WebSocketProtocol17(WebSocketProtocol):
             newFrame.append(127)
             newFrame += struct.pack('!Q', length)
 
-        newFrame += message.encode('utf-8')
+        newFrame += message
         self.transport.write(str(newFrame))
 
 


### PR DESCRIPTION
Not everything sent to sendMessage is necessarily valid unicode. For example, when Firefox closes the connection, a control frame is sent that is not valid utf-8. (The one Chrome sends is apparently ok)

Also, checking the length of the unicode-string is wrong, as it can be shorter than the encoded length.

Without this patch, try running the echo-demo. Opening it in Firefox (14.0.1 here) and then closing the tab gives a traceback like

```
  ...
  File "[snip]/cyclone-1.0_rc8-py2.7.egg/cyclone/websocket.py", line 268, in sendMessage
    message = unicode(message, "utf-8")
exceptions.UnicodeDecodeError: 'utf8' codec can't decode byte 0xe9 in position 1: unexpected end of data
```

Reopening and trying to echo unicode (e.g. "æøå") results in a closed connection without anything echoed back.

Trying the same in Chrome, it usually behaves the same – but I got it to echo a truncated message once as well.
