### PR TITLE
Mail.py encondig problem and other change

### DIFF
--- a/cyclone/mail.py
+++ b/cyclone/mail.py
@@ -51,8 +51,7 @@ class Message(object):
         self.message = MIMEText(message, _charset=charset)
         self.message.set_type(mime)
 
-    def attach(self, filename, mime=None, charset=None, content=None,
-               attach_filename=None):
+    def attach(self, filename, mime=None, charset=None, content=None):
         base = os.path.basename(filename)
         if content is None:
             fd = open(filename)
@@ -65,10 +64,8 @@ class Message(object):
         part = MIMEBase("application", "octet-stream")
         part.set_payload(content)
         Encoders.encode_base64(part)
-        if attach_filename is None:
-            attach_filename = base
         part.add_header("Content-Disposition",
-                        'attachment; filename="%s"' % attach_filename)
+                        'attachment; filename="%s"' % base)
 
         if mime is not None:
             part.set_type(mime)


### PR DESCRIPTION
Hi,

I've made this small changes to mail.py:
1. Added a attach_filename to the attach() method. I needed this to define the attachment filename since, in my case, the actual filename on the filesystem doesn't match the real filename from the database;
2. Changed the intantiation of MIMEText to pass the charset to initialize. I did this because the default charset is "us_ascii", and was causing troubles with my utf-8 messages. :-)

I hope this is somewhat helpful to make to the official repo ;-)

Thanks!
