### PR TITLE
postinst script copy twisted plugin to the respective dir

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+python-cyclone (1.0-rc11) unstable; urgency=low
+
+  * Fix postinst script to install twisted plugin o python2.5 as well as
+    python2.6
+
+ -- Rodrigo Sampaio Vaz <rodrigo.vaz@gmail.com>  Tue, 21 Ago 2012 15:48:22 -0300
+
 python-cyclone (1.0-rc9) unstable; urgency=low
 
   * Version synch with git repo

--- a/debian/postinst
+++ b/debian/postinst
@@ -11,7 +11,12 @@ rebuild_cache()
     for p in $(pyversions -i); do
 	$p -c 'from twisted.plugin import IPlugin, getPlugins; list(getPlugins(IPlugin))' \
 	  >/dev/null 2>&1 || true
+    if [ -d /usr/lib/${p}/dist-packages/twisted/plugins ]; then
         ln -sf /usr/share/pyshared/twisted/plugins/cyclone_plugin.py /usr/lib/${p}/dist-packages/twisted/plugins/
+    elif [ -d /usr/lib/${p}/site-packages/twisted/plugins ]; then
+        ln -sf /usr/share/pyshared/twisted/plugins/cyclone_plugin.py /usr/lib/${p}/site-packages/twisted/plugins/
+    fi
+
     done
 }
 


### PR DESCRIPTION
On debian squeeze, twisted plugins for python2.5 lives on site-packages dir, for 2.6 it is on dist-packages dir, the script now checks if the directory exist and copy if true
