### PR TITLE
Implement stack trace printing for exceptions when in debug mode

### DIFF
--- a/cyclone/web.py
+++ b/cyclone/web.py
@@ -1312,7 +1312,17 @@ class Application(protocol.ServerFactory):
             for spec in handlers:
                 match = spec.regex.match(request.path)
                 if match:
-                    handler = spec.handler_class(self, request, **spec.kwargs)
+                    # If we are in debug mode
+                    #
+                    if self.settings.get("debug"):
+                        try:
+                            handler = spec.handler_class(self, request, **spec.kwargs)
+                        except:
+                            traceback.print_exc()
+                            handler = ErrorHandler(self, request, status_code=500)
+                    else:
+                        handler = spec.handler_class(self, request, **spec.kwargs)
+
                     if spec.regex.groups:
                         # None-safe wrapper around url_unescape to handle
                         # unmatched optional groups correctly


### PR DESCRIPTION
I implemented this to allow me to print out stack traces when there are errors in my handlers. It will only work when the debug mode flag is enabled. If that is not enabled it will use the default behavior.
