### PR TITLE
Update documentation to say 'cyclone' instead of 'tornado'

### DIFF
--- a/cyclone/auth.py
+++ b/cyclone/auth.py
@@ -31,8 +31,8 @@ See the individual service classes below for complete documentation.
 
 Example usage for Google OpenID:
 
-class GoogleHandler(tornado.web.RequestHandler, tornado.auth.GoogleMixin):
-    @tornado.web.asynchronous
+class GoogleHandler(cyclone.web.RequestHandler, cyclone.auth.GoogleMixin):
+    @cyclone.web.asynchronous
     def get(self):
         if self.get_argument("openid.mode", None):
             self.get_authenticated_user(self.async_callback(self._on_auth))
@@ -41,7 +41,7 @@ class GoogleHandler(tornado.web.RequestHandler, tornado.auth.GoogleMixin):
 
     def _on_auth(self, user):
         if not user:
-            raise tornado.web.HTTPError(500, "Google auth failed")
+            raise cyclone.web.HTTPError(500, "Google auth failed")
         # Save the user with, e.g., set_secure_cookie()
 
 """
@@ -353,9 +353,9 @@ class TwitterMixin(OAuthMixin):
     When your application is set up, you can use this Mixin like this
     to authenticate the user with Twitter and get access to their stream:
 
-    class TwitterHandler(tornado.web.RequestHandler,
-                         tornado.auth.TwitterMixin):
-        @tornado.web.asynchronous
+    class TwitterHandler(cyclone.web.RequestHandler,
+                         cyclone.auth.TwitterMixin):
+        @cyclone.web.asynchronous
         def get(self):
             if self.get_argument("oauth_token", None):
                 self.get_authenticated_user(self.async_callback(self._on_auth))
@@ -364,7 +364,7 @@ class TwitterMixin(OAuthMixin):
 
         def _on_auth(self, user):
             if not user:
-                raise tornado.web.HTTPError(500, "Twitter auth failed")
+                raise cyclone.web.HTTPError(500, "Twitter auth failed")
             # Save the user using, e.g., set_secure_cookie()
 
     The user object returned by get_authenticated_user() includes the
@@ -410,14 +410,14 @@ class TwitterMixin(OAuthMixin):
         attribute that can be used to make authenticated requests via
         this method. Example usage:
 
-        class MainHandler(tornado.web.RequestHandler,
-                          tornado.auth.TwitterMixin):
-            @tornado.web.authenticated
-            @tornado.web.asynchronous
+        class MainHandler(cyclone.web.RequestHandler,
+                          cyclone.auth.TwitterMixin):
+            @cyclone.web.authenticated
+            @cyclone.web.asynchronous
             def get(self):
                 self.twitter_request(
                     "/statuses/update",
-                    post_args={"status": "Testing Tornado Web Server"},
+                    post_args={"status": "Testing cyclone Web Server"},
                     access_token=user["access_token"],
                     callback=self.async_callback(self._on_post))
 
@@ -492,9 +492,9 @@ class FriendFeedMixin(OAuthMixin):
     When your application is set up, you can use this Mixin like this
     to authenticate the user with FriendFeed and get access to their feed:
 
-    class FriendFeedHandler(tornado.web.RequestHandler,
-                            tornado.auth.FriendFeedMixin):
-        @tornado.web.asynchronous
+    class FriendFeedHandler(cyclone.web.RequestHandler,
+                            cyclone.auth.FriendFeedMixin):
+        @cyclone.web.asynchronous
         def get(self):
             if self.get_argument("oauth_token", None):
                 self.get_authenticated_user(self.async_callback(self._on_auth))
@@ -503,7 +503,7 @@ class FriendFeedMixin(OAuthMixin):
 
         def _on_auth(self, user):
             if not user:
-                raise tornado.web.HTTPError(500, "FriendFeed auth failed")
+                raise cyclone.web.HTTPError(500, "FriendFeed auth failed")
             # Save the user using, e.g., set_secure_cookie()
 
     The user object returned by get_authenticated_user() includes the
@@ -535,14 +535,14 @@ class FriendFeedMixin(OAuthMixin):
         attribute that can be used to make authenticated requests via
         this method. Example usage:
 
-        class MainHandler(tornado.web.RequestHandler,
-                          tornado.auth.FriendFeedMixin):
-            @tornado.web.authenticated
-            @tornado.web.asynchronous
+        class MainHandler(cyclone.web.RequestHandler,
+                          cyclone.auth.FriendFeedMixin):
+            @cyclone.web.authenticated
+            @cyclone.web.asynchronous
             def get(self):
                 self.friendfeed_request(
                     "/entry",
-                    post_args={"body": "Testing Tornado Web Server"},
+                    post_args={"body": "Testing cyclone Web Server"},
                     access_token=self.current_user["access_token"],
                     callback=self.async_callback(self._on_post))
 
@@ -614,8 +614,8 @@ class GoogleMixin(OpenIdMixin, OAuthMixin):
     values for the user, including 'email', 'name', and 'locale'.
     Example usage:
 
-    class GoogleHandler(tornado.web.RequestHandler, tornado.auth.GoogleMixin):
-       @tornado.web.asynchronous
+    class GoogleHandler(cyclone.web.RequestHandler, cyclone.auth.GoogleMixin):
+       @cyclone.web.asynchronous
        def get(self):
            if self.get_argument("openid.mode", None):
                self.get_authenticated_user(self.async_callback(self._on_auth))
@@ -624,7 +624,7 @@ class GoogleMixin(OpenIdMixin, OAuthMixin):
 
         def _on_auth(self, user):
             if not user:
-                raise tornado.web.HTTPError(500, "Google auth failed")
+                raise cyclone.web.HTTPError(500, "Google auth failed")
             # Save the user with, e.g., set_secure_cookie()
 
     """
@@ -689,9 +689,9 @@ class FacebookMixin(object):
     When your application is set up, you can use this Mixin like this
     to authenticate the user with Facebook:
 
-    class FacebookHandler(tornado.web.RequestHandler,
-                          tornado.auth.FacebookMixin):
-        @tornado.web.asynchronous
+    class FacebookHandler(cyclone.web.RequestHandler,
+                          cyclone.auth.FacebookMixin):
+        @cyclone.web.asynchronous
         def get(self):
             if self.get_argument("session", None):
                 self.get_authenticated_user(self.async_callback(self._on_auth))
@@ -700,7 +700,7 @@ class FacebookMixin(object):
 
         def _on_auth(self, user):
             if not user:
-                raise tornado.web.HTTPError(500, "Facebook auth failed")
+                raise cyclone.web.HTTPError(500, "Facebook auth failed")
             # Save the user using, e.g., set_secure_cookie()
 
     The user object returned by get_authenticated_user() includes the
@@ -783,10 +783,10 @@ class FacebookMixin(object):
 
         Here is an example for the stream.get() method:
 
-        class MainHandler(tornado.web.RequestHandler,
-                          tornado.auth.FacebookMixin):
-            @tornado.web.authenticated
-            @tornado.web.asynchronous
+        class MainHandler(cyclone.web.RequestHandler,
+                          cyclone.auth.FacebookMixin):
+            @cyclone.web.authenticated
+            @cyclone.web.asynchronous
             def get(self):
                 self.facebook_request(
                     method="stream.get",

--- a/cyclone/escape.py
+++ b/cyclone/escape.py
@@ -240,8 +240,8 @@ def linkify(text, shorten=False, extra_params="",
             require_protocol=False, permitted_protocols=["http", "https"]):
     """Converts plain text into HTML with links.
 
-    For example: ``linkify("Hello http://tornadoweb.org!")`` would return
-    ``Hello <a href="http://tornadoweb.org">http://tornadoweb.org</a>!``
+    For example: ``linkify("Hello http://cyclone.io!")`` would return
+    ``Hello <a href="http://cyclone.io">http://cyclone.io</a>!``
 
     Parameters:
 

--- a/cyclone/options.py
+++ b/cyclone/options.py
@@ -452,7 +452,7 @@ class _LogFormatter(logging.Formatter):
         # but don't do it by default so we don't add extra quotes to ascii
         # bytestrings.  This is a bit of a hacky place to do this, but
         # it's worth it since the encoding errors that would otherwise
-        # result are so useless (and tornado is fond of using utf8-encoded
+        # result are so useless (and cyclone is fond of using utf8-encoded
         # byte strings whereever possible).
         try:
             message = _unicode(record.message)

--- a/cyclone/template.py
+++ b/cyclone/template.py
@@ -81,7 +81,7 @@ to all templates by default.
 
 Typical applications do not create `Template` or `Loader` instances by
 hand, but instead use the `render` and `render_string` methods of
-`tornado.web.RequestHandler`, which load templates automatically based
+`cyclone.web.RequestHandler`, which load templates automatically based
 on the ``template_path`` `Application` setting.
 
 Syntax Reference
@@ -161,7 +161,7 @@ with ``{# ... #}``.
     to include another template with an isolated namespace.
 
 ``{% module *expr* %}``
-    Renders a `~tornado.web.UIModule`.  The output of the ``UIModule`` is
+    Renders a `~cyclone.web.UIModule`.  The output of the ``UIModule`` is
     not escaped::
 
         {% module Template("foo.html", arg=42) %}

--- a/cyclone/util.py
+++ b/cyclone/util.py
@@ -35,10 +35,10 @@ def import_object(name):
 
     import_object('x.y.z') is equivalent to 'from x.y import z'.
 
-    >>> import tornado.escape
-    >>> import_object('tornado.escape') is tornado.escape
+    >>> import cyclone.escape
+    >>> import_object('cyclone.escape') is cyclone.escape
     True
-    >>> import_object('tornado.escape.utf8') is tornado.escape.utf8
+    >>> import_object('cyclone.escape.utf8') is cyclone.escape.utf8
     True
     """
     parts = name.split('.')

--- a/cyclone/web.py
+++ b/cyclone/web.py
@@ -177,7 +177,7 @@ class RequestHandler(object):
 
     def clear(self):
         """Resets all headers and content for this response."""
-        # The performance cost of tornado.httputil.HTTPHeaders is significant
+        # The performance cost of cyclone.httputil.HTTPHeaders is significant
         # (slowing down a benchmark with a trivial handler by more than 10%),
         # and its case-normalization is not generally necessary for
         # headers we generate on the server side, so use a plain dict
@@ -933,7 +933,7 @@ class RequestHandler(object):
         """Computes the etag header to be used for this request.
 
         May be overridden to provide custom etag implementations,
-        or may return None to disable tornado's default etag support.
+        or may return None to disable cyclone's default etag support.
         """
         hasher = hashlib.sha1()
         for part in self._write_buffer:
@@ -1615,12 +1615,12 @@ class FallbackHandler(RequestHandler):
     """A RequestHandler that wraps another HTTP server callback.
 
     The fallback is a callable object that accepts an HTTPRequest,
-    such as an Application or tornado.wsgi.WSGIContainer.  This is most
-    useful to use both tornado RequestHandlers and WSGI in the same server.
+    such as an Application or cyclone.wsgi.WSGIContainer.  This is most
+    useful to use both cyclone RequestHandlers and WSGI in the same server.
     Typical usage:
-        wsgi_app = tornado.wsgi.WSGIContainer(
+        wsgi_app = cyclone.wsgi.WSGIContainer(
             django.core.handlers.wsgi.WSGIHandler())
-        application = tornado.web.Application([
+        application = cyclone.web.Application([
             (r"/foo", FooHandler),
             (r".*", FallbackHandler, dict(fallback=wsgi_app),
         ])


### PR DESCRIPTION
Fix the examples and documentation strings so that they refer to the
'cyclone' modules.
