### PR TITLE
No method to add custom headers for mail

### DIFF
--- a/cyclone/mail.py
+++ b/cyclone/mail.py
@@ -96,6 +96,12 @@ class Message(object):
 
         return StringIO(self.__cache)
 
+    def add_header(self, key, value, **params):
+        if self.msg is None:
+            self.msg = self.message
+
+        self.msg.add_header(key, value, **params)
+
 
 def sendmail(mailconf, message):
     """Takes a regular dictionary as mailconf, as follows:


### PR DESCRIPTION
I wanted to add some custom SMTP headers for the mails I generate but there seems to be no option to do that. So I have just added a function to add headers to the mail.
Hope it will be useful for all.
