### PR TITLE
Updated email demo to demonstrate add_header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -676,3 +676,7 @@ Thanks to (in no particular order):
 - `Flavio Grossi <https://github.com/flaviogrossi>`_
 
   - Minor code fixes and websockets chat statistics example
+
+- `Gautam Jeyaraman <https://github.com/gautamjeyaraman>`_
+
+  - Minor code fixes and patches

--- a/cyclone/mail.py
+++ b/cyclone/mail.py
@@ -65,7 +65,7 @@ class Message(object):
         part.set_payload(content)
         Encoders.encode_base64(part)
         part.add_header("Content-Disposition",
-                        'attachment; filename="%s"' % base)
+                        "attachment", filename=base)
 
         if mime is not None:
             part.set_type(mime)

--- a/demos/email/emaildemo.py
+++ b/demos/email/emaildemo.py
@@ -75,6 +75,8 @@ class SendmailHandler(cyclone.web.RequestHandler):
         msg.attach("fake.txt", mime="text/plain", charset="utf-8",
                    content="this file is fake!")
 
+        msg.add_header('X-MailTag', 'sampleUpload')  # custom email header
+
         try:
             response = yield cyclone.mail.sendmail(
                                 self.settings.email_settings, msg)


### PR DESCRIPTION
I have updated the email demo with add_header.
Also made a very small fix in mail.py because the older way seemed like a bit of a hack.
Thank you.
