### PR TITLE
fix locale initialization in default app skel

### DIFF
--- a/appskel/default/modname/web.py
+++ b/appskel/default/modname/web.py
@@ -23,8 +23,8 @@ class Application(cyclone.web.Application):
         conf = config.parse_config(config_file)
 
         # Initialize locales
-        if "locales" in conf:
-            cyclone.locale.load_gettext_translations(conf["locales"],
+        if "locale_path" in conf:
+            cyclone.locale.load_gettext_translations(conf["locale_path"],
                                                      "$modname")
 
         # Set up database connections


### PR DESCRIPTION
In default application skeleton additional locales
could not be initialized because of using wrong config
key 'locales' (must be 'locale_path'). Fixed.
