### PR TITLE
fix removing entire twisted when uninstalling cyclone

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,31 @@ else:
     setup = setuptools.setup
     extra = dict(install_requires=requires)
 
+    try:
+        from setuptools.command import egg_info
+        egg_info.write_toplevel_names
+    except (ImportError, AttributeError):
+        pass
+    else:
+        """
+        'twisted' should not occur in the top_level.txt file as this 
+        triggers a bug in pip that removes all of twisted when a package
+        with a twisted plugin is removed.
+        """
+        def _top_level_package(name):
+            return name.split('.', 1)[0]
+    
+        def _hacked_write_toplevel_names(cmd, basename, filename):
+            pkgs = dict.fromkeys(
+                [_top_level_package(k)
+                    for k in cmd.distribution.iter_distribution_names()
+                    if _top_level_package(k) != "twisted"
+                ]
+            )
+            cmd.write_file("top-level names", filename, '\n'.join(pkgs) + '\n')
+    
+        egg_info.write_toplevel_names = _hacked_write_toplevel_names
+
 
 setup(
     name="cyclone",


### PR DESCRIPTION
This is [issue86](https://github.com/fiorix/cyclone/issues/86) related.

I found a solution in Ralph Meijer's Wokkel repo - look at this [commit](https://github.com/ralphm/wokkel/commit/bb83eb66896e99848d4426f6dc8b23b88f0b35bc#setup.py)

It seems to work as expected now. In new virtualenv:

``` bash
$ pip install twisted
....
$ pip install git+https://github.com/FZambia/cyclone.git@plugin_fix
...
$ pip uninstall cyclone
Uninstalling cyclone:
  /private/var/www/different/python/cyclone/issue86/env/bin/cyclone
  /private/var/www/different/python/cyclone/issue86/env/lib/python2.7/site-packages/cyclone
  /private/var/www/different/python/cyclone/issue86/env/lib/python2.7/site-packages/cyclone-git_2013011801-py2.7.egg-info
  /private/var/www/different/python/cyclone/issue86/env/lib/python2.7/site-packages/twisted/plugins/cyclone_plugin.py
  /private/var/www/different/python/cyclone/issue86/env/lib/python2.7/site-packages/twisted/plugins/cyclone_plugin.pyc
Proceed (y/n)? 
...
```
