### PR TITLE
Create a fallback route that is called if no other route matches.  Fixes #108

### DIFF
--- a/cyclone/bottle.py
+++ b/cyclone/bottle.py
@@ -61,6 +61,12 @@ def route(path=None, method="GET", callback=None, **kwargs):
         @route("/foobar", method="post")
         def whatever(cli):
             ...
+
+    Set method to "ANY" to have the route be called on method.::
+
+        @route("/foobar", method="any")
+        def all_routes(cli):
+            ...
     """
     if callable(path):
         path, callback = None, path

--- a/cyclone/web.py
+++ b/cyclone/web.py
@@ -172,6 +172,17 @@ class RequestHandler(object):
         return self.application.settings
 
     def default(self, *args, **kwargs):
+        """Called when a request does not match any implemented methods.
+
+        Example::
+
+            class ExampleHandler(RequestHandler):
+                def get(self):
+                    self.write('That was a GET request!')
+
+                def default(self):
+                    self.write('That was anything but a GET request!')
+        """
         raise HTTPError(405)
 
     def prepare(self):

--- a/website/sphinx/web.rst
+++ b/website/sphinx/web.rst
@@ -17,12 +17,13 @@
    Implement any of the following methods to handle the corresponding
    HTTP method.
 
-   .. automethod:: RequestHandler.get
-   .. automethod:: RequestHandler.post
-   .. automethod:: RequestHandler.put
-   .. automethod:: RequestHandler.delete
-   .. automethod:: RequestHandler.head
-   .. automethod:: RequestHandler.options
+   .. method:: RequestHandler.get(*args, **kwargs)
+   .. method:: RequestHandler.post(*args, **kwargs)
+   .. method:: RequestHandler.put(*args, **kwargs)
+   .. method:: RequestHandler.delete(*args, **kwargs)
+   .. method:: RequestHandler.head(*args, **kwargs)
+   .. method:: RequestHandler.options(*args, **kwargs)
+   .. automethod:: RequestHandler.default
 
    Input
    ^^^^^


### PR DESCRIPTION
Hello.

This adds a fallback route to cyclone's `RequestHandler` that is called when no other route matches.  It also supports bottle style route decorators.

``` python
class MainHandler(RequestHandler):
    def get(self):
        # This is called on get requests
        self.write("This is a GET request.")

    def default(self):
        # This is called on all other requests.
        self.write("This is a supported request that isn't a GET.")
```

And for bottle style routing:

``` python
@route('/', method='get')
def get(web):
    web.write("This is a GET request.")

@route("/", method='ANY')
def index(web):
    web.write("This is a supported request that isn't a GET.")
```
