### PR TITLE
some fixes for websocket protocol 76

### DIFF
--- a/cyclone/websocket.py
+++ b/cyclone/websocket.py
@@ -355,7 +355,7 @@ class WebSocketProtocol76(WebSocketProtocol):
     def rawDataReceived(self, data):
         if self._postheader is True and \
            self._protocol >= 76 and len(data) == 8:
-            self._nonce = data.strip()
+            self._nonce = data
             token = self._calculate_token(self._k1, self._k2, self._nonce)
             self.transport.write(
                 "HTTP/1.1 101 Web Socket Protocol Handshake\r\n"


### PR DESCRIPTION
hi,

i think i found some problems with the current implementation of the hixie-76 protocol's handshake:
1. the received nonce should not be stripped, since the random bytes sent by the client could contain leading or trailing whitespace
2. when the http upgrade response is sent to the client, it sends a double \r\n immediately after the challenge response (token)
3. after having written the upgrade response for the client via transport.write(), a call to self.handler.flush() is made which to me seems unnecessary (and in fact it is not made for the hybi protocol). Actually, i think it may create problems, since it could append to the handshake some extra requests, especially if handler.transform is not empty

please review the attached changes in case there's something wrong

thanks,
flavio
