### PR TITLE
some fixes for the hixie protocol

### DIFF
--- a/cyclone/websocket.py
+++ b/cyclone/websocket.py
@@ -299,6 +299,8 @@ class WebSocketProtocol17(WebSocketProtocol):
                 payload[k] ^= frame_mask_array[k % 4]
 
             return str(payload)
+        else:
+            return data[i:i+self._frame_payload_len]
 
     def sendMessage(self, message, code=0x81):
         if isinstance(message, unicode):


### PR DESCRIPTION
hi,
i think i have spotted some other problems with the old hixie protocol:
1. it seems the server never sends an '\xff\x00' frame to the client to close the connection
2. the code for receiving data from client seems to expect that the rawDataReceived() is always called with the entire frame from the client, ignoring buffering. I think it should properly accumulate data before processing the frames
3. according to the standard, it should be possible to send the upgrade header and the challenge token in two separate steps, and the server should send the headers right away and later the challenge response (when received)

number one can be reproduced by using the client here [1] while enabling debug in the client (enableTrace(True) as the first line in the __main__ code)

number two can be exposed by simply using the client above and sending a big string. E.g. ws.send(100_1024_'a')

number three is explained here [2]

the proposed change should fix these issues. Please review and tell me if you find some problems.

also, i think in hybi protocol, when processing a message, if no mask is used, the function _extractMessageFromFrame() returns None, and an exception will be raised because None will be appended to an existing string.

thanks,
flavio

[1] https://gist.github.com/flaviogrossi/6345654
[2] http://sockjs.github.io/sockjs-protocol/sockjs-protocol-0.3.3.html#section-63
