### PR TITLE
pass kwargs to request handler's initialize method

### DIFF
--- a/cyclone/web.py
+++ b/cyclone/web.py
@@ -145,7 +145,7 @@ class RequestHandler(object):
         self.request.connection.no_keep_alive = self.no_keep_alive
         self.initialize(**kwargs)
 
-    def initialize(self):
+    def initialize(self, **kwargs):
         """Hook for subclass initialization.
 
         A dictionary passed as the third argument of a url spec will be


### PR DESCRIPTION
hi again :)

i know that the main purpose of RequestHandler.initialize() method is to be overridden in derived classes, however, it would be nice for the base method to receive the kwargs argument as it is documented in the docstring.

this is useful (and i'm using it this way), when the requesthandlers are dynamically chosen and some of them overrides initialize() while others don't. With the current code, an exception is raised because the empty method doesn't expect arguments.

also, this is exactly how the code used to be just a couple of months ago (and the docs still report it that way), and i believe it is the correct behaviour

thank you,
flavio
