### PR TITLE
Fixed bug which was disallowing to make HEAD requests with cyclone.httpclient.

### DIFF
--- a/cyclone/httpclient.py
+++ b/cyclone/httpclient.py
@@ -136,7 +136,7 @@ class HTTPClient(object):
         response.headers = dict(response.headers.getAllRawHeaders())
         # HTTP 204 and 304 responses have no body
         # http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-        # resources, which have been requested with HEAD method
+        # responses, which have been requested with HEAD method
         # have no body too.
         # http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html
         if response.code in (204, 304) or self.method == 'HEAD':


### PR DESCRIPTION
httpclient should be able to make HEAD requests now.
Script to reproduce bug fixed in my pull request:

``` python
from twisted.internet import reactor
from cyclone.httpclient import fetch

resp = fetch("http://ya.ru", method="HEAD")

def ok(self, resp):
   print "OK"

def fail(self, failure):
   print "FAIL"

resp.addCallback(ok)
resp.addErrback(fail)

if __name__ == "__main__":
   reactor.run()
```

When launched with python test.py (assuming you have cyclone in your pythonpath) should hang forever.
