### PR TITLE
Send proper content type header in jsonrpc client

### DIFF
--- a/cyclone/httpclient.py
+++ b/cyclone/httpclient.py
@@ -223,7 +223,14 @@ class JsonRPC:
                                 "id": self.__rpcId})
         self.__rpcId += 1
         r = defer.Deferred()
-        d = fetch(self.__rpcUrl, method="POST", postdata=q)
+        d = fetch(
+            self.__rpcUrl,
+            method="POST",
+            postdata=q,
+            headers={
+                "Content-Type": "application/json-rpc"
+            }
+        )
 
         def _success(response, deferred):
             if response.code == 200:


### PR DESCRIPTION
 http://www.jsonrpc.org/historical/json-rpc-over-http.html#http-header
Despite this specification is a draft, many existing implementations rely on it.
In my case rpc4django (package which implements jsonrpc and xmlrpc for Django web framework) was poisoning Sentry with warnings without this header.
