### PR TITLE
simple fix for an anoying problem using unicode literals

### DIFF
--- a/cyclone/mail.py
+++ b/cyclone/mail.py
@@ -158,6 +158,10 @@ def sendmail(mailconf, message):
         raise TypeError("message must be an instance of cyclone.mail.Message")
 
     host = mailconf.get("host")
+
+    if isinstance(host, unicode):
+        host = str(unicode)
+
     if not isinstance(host, types.StringType):
         raise ValueError("mailconf requires a 'host' configuration")
 


### PR DESCRIPTION
hi! i'm sending a simple bug fix for a problem i face everytime i want to send a mail using cyclone: it seems that it just expects a string, but this is quite hard when using unicode_literals in the whole application :) since i always have to str(param) to the mail, i made this conversion into a pull request :)

best regards,
richard.
