### PR TITLE
Prevents an invalid redirect from being performed via a malformed request

### DIFF
--- a/cyclone/web.py
+++ b/cyclone/web.py
@@ -488,7 +488,13 @@ class RequestHandler(object):
         self.set_status(status)
         # Remove whitespace
         url = re.sub(r"[\x00-\x20]+", "", utf8(url))
-        self.set_header("Location", urlparse.urljoin(utf8(self.request.uri),
+        if not self.request.uri.startswith('/'):
+            request_uri = ''
+        if self.request.uri.startswith('//'):
+            request_uri = ''
+        else:
+            request_uri = self.request.uri
+        self.set_header("Location", urlparse.urljoin(utf8(request_uri),
                                                      url))
         self.finish()
 


### PR DESCRIPTION
If the redirect function is called with a request such as http://www.example.com//www.someotherwebsite.com, the client receives a Location header of //www.someotherwebsite.com, causing it to perform a redirect to the specified domain.

Additionally, inspecting for a uri prefix of '/' prevents the possibility of introducing other malicious redirect requests.
