### PR TITLE
Fix small doco bug in mail.Message.

### DIFF
--- a/cyclone/mail.py
+++ b/cyclone/mail.py
@@ -49,6 +49,7 @@ class Message(object):
                 from_addr="root@localhost",
                 to_addrs=["user1", "user2", "user3"],
                 subject="Test, 123",
+                message="Hello thar!",
                 mime="text/html")
     """
 


### PR DESCRIPTION
You have to read the source to figure out what is going on if you don't pass message as a param. This updates the example docs to show the correct invocation.
