### PR TITLE
Feature/hooks

### DIFF
--- a/cyclone/httpserver.py
+++ b/cyclone/httpserver.py
@@ -76,6 +76,7 @@ class HTTPConnection(basic.LineReceiver):
         self._finish_callback = None
         self.no_keep_alive = False
         self.content_length = None
+        self.content_disposition = None
         self.request_callback = self.factory
         self.xheaders = self.factory.settings.get('xheaders', False)
         self._request = None

--- a/cyclone/tests/test_httpserver.py
+++ b/cyclone/tests/test_httpserver.py
@@ -237,6 +237,7 @@ class HTTPConnectionTest(unittest.TestCase):
 
     def test_on_request_body_post_multipart_form_data(self):
         self.con.request_callback = Mock()
+        self.con.connectionMade()
         self.con._request = Mock()
         self.con._request.arguments = {}
         self.con._request.method = "POST"

--- a/cyclone/web.py
+++ b/cyclone/web.py
@@ -1401,7 +1401,9 @@ class Application(protocol.ServerFactory):
         self.protocol.no_multipart = self.settings.get("no_multipart", False)
         self.protocol.form_urlencoded_maximum_size = \
             self.settings.get("form_urlencoded_maximum_size", None)
-
+        self.protocol.get_content_buffer = \
+            self.settings.get("get_content_buffer",
+                              self.protocol.get_content_buffer)
 
     def add_handlers(self, host_pattern, host_handlers):
         """Appends the given handlers to our handler list.

--- a/cyclone/web.py
+++ b/cyclone/web.py
@@ -1398,6 +1398,11 @@ class Application(protocol.ServerFactory):
         if handlers:
             self.add_handlers(".*$", handlers)
 
+        self.protocol.no_multipart = self.settings.get("no_multipart", False)
+        self.protocol.form_urlencoded_maximum_size = \
+            self.settings.get("form_urlencoded_maximum_size", None)
+
+
     def add_handlers(self, host_pattern, host_handlers):
         """Appends the given handlers to our handler list.
 


### PR DESCRIPTION
This pull requests implements a series of new features:

1) The ability to disable multipart parsing from a configurable option

2) The ability to set a maximum size for form-urlencoded requests

3) A hook that can be override by the web application developer for generating the content buffer (see https://github.com/hellais/GLBackend/blob/62285a17fcbd6743f42173b2e7e922255dc3fc5b/globaleaks/backend.py#L24 for an example use case)

4) Support for handling `Content-Disposition` and `Range` HTTP Headers

If you want to discuss more about this merge I am available on IRC on #twisted (Freenode) or on #globaleaks (OFTC).
