### PR TITLE
Forgot to pass `kwargs` in the `RequestHandler.reverse_url` method.

### DIFF
--- a/cyclone/web.py
+++ b/cyclone/web.py
@@ -1080,7 +1080,7 @@ class RequestHandler(object):
 
     def reverse_url(self, name, *args, **kwargs):
         """Alias for `Application.reverse_url`."""
-        return self.application.reverse_url(name, *args)
+        return self.application.reverse_url(name, *args, **kwargs)
 
     def compute_etag(self):
         """Computes the etag header to be used for this request.
@@ -2155,7 +2155,7 @@ class URLSpec(object):
                 if not isinstance(a, (unicode_type, bytes_type)):
                     a = str(a)
                 converted_args.append(escape.url_escape(utf8(a)))
-            
+
             rv = rv % tuple(converted_args)
 
         if kwargs:


### PR DESCRIPTION
Hi,

This is a follow-up to my previous pull request (#146). 

I've forgotten to pass kwargs from  `RequestHandler.reverse_url` to `Application.reverse_url`.

Sorry.
