### PR TITLE
Changing setup.py dependancies to pyopenssl to make it optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,11 @@ else:
 if sys.subversion[0].lower().startswith("pypy"):
     import distutils.core
     setup = distutils.core.setup
-    extra = dict(requires=requires)
+    extra = dict(extras_require={'ssl': requires})
 else:
     import setuptools
     setup = setuptools.setup
-    extra = dict(install_requires=requires)
+    extra = dict(extras_require={'ssl': requires})
 
     try:
         from setuptools.command import egg_info


### PR DESCRIPTION
We ran : 

```
"coverage run `which trial` cyclone
```

successfully with both distribute and setuptools, but tested it only against Python 2.7 on Ubuntu 14.04.

I'll make a separate PR for the documentation.
