### PR TITLE
Allow custom json encoding in jsonrpc handler.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.6"
     - "2.7"
     - "pypy"
 

--- a/cyclone/jsonrpc.py
+++ b/cyclone/jsonrpc.py
@@ -36,9 +36,21 @@ from twisted.python import log, failure
 class JsonrpcRequestHandler(RequestHandler):
     """Subclass this class and define jsonrpc_* to make a handler.
 
+    The response and request for your jsonrpc_* methods will be de/encoded with
+    JsonrpcRequestHandler.encoder. By default that is set to cyclone.escape
+    but you can override that for all JsonrpcRequestHandlers by setting it
+    at the class level, or in each subclass (see the example):
+
+        JsonrpcRequestHandler.encoder = myencoder
+
+    The only requirement of setting a custom encoder is that it has
+    two callable attributes: json_encode and json_decode.
+
     Example::
 
         class MyRequestHandler(JsonrpcRequestHandler):
+            encoder = MyCustomEncoder()  # optional
+
             def jsonrpc_echo(self, text):
                 return text
 
@@ -50,18 +62,35 @@ class JsonrpcRequestHandler(RequestHandler):
                 response = yield cyclone.httpclient.fetch(
                     "http://freegeoip.net/json/%s" % address.encode("utf-8"))
                 defer.returnValue(response.body)
+
+    Example hybrid encoder::
+
+        class DateTimeAwareEncoder(object):
+
+            json_decode = lambda self, *args, **kwargs:\
+                cyclone.escape.json_decode(*args, **kwargs)
+
+            def default_encode(self, value):
+                if isinstance(value, datetime):
+                    return value.isoformat()
+
+            json_encode = lambda self, *args, **kwargs:\
+                json.dumps(default=self.default_encode, *args, **kwargs)
     """
+
+    encoder = cyclone.escape
+
     def post(self, *args):
         self._auto_finish = False
         try:
-            req = cyclone.escape.json_decode(self.request.body)
+            req = self.encoder.json_decode(self.request.body)
             jsonid = req["id"]
             method = req["method"]
             assert isinstance(method, types.StringTypes), \
-                              "Invalid method type: %s" % type(method)
+                "Invalid method type: %s" % type(method)
             params = req.get("params", [])
             assert isinstance(params, (types.ListType, types.TupleType)), \
-                              "Invalid params type: %s" % type(params)
+                "Invalid params type: %s" % type(params)
         except Exception, e:
             log.msg("Bad Request: %s" % str(e))
             raise HTTPError(400)
@@ -82,4 +111,4 @@ class JsonrpcRequestHandler(RequestHandler):
         else:
             error = None
         data = {"result": result, "error": error, "id": jsonid}
-        self.finish(cyclone.escape.json_encode(data))
+        self.finish(self.encoder.json_encode(data))

--- a/cyclone/tests/test_jsonrpc.py
+++ b/cyclone/tests/test_jsonrpc.py
@@ -1,0 +1,35 @@
+#
+# Copyright 2014 David Novakovic
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from twisted.trial import unittest
+from mock import Mock
+from cyclone.jsonrpc import JsonrpcRequestHandler
+from cyclone.web import Application
+
+
+class TestJsonrpcRequestHandler(unittest.TestCase):
+
+    def setUp(self):
+        self.request = Mock()
+        self.app = Application()
+        self.handler = JsonrpcRequestHandler(self.app, self.request)
+        self.handler.finish = Mock()
+
+    def test_post(self):
+        self.handler.jsonrpc_foo = lambda: "value"
+        self.handler.request.body = '{"id":1, "method":"foo"}'
+        self.handler.post()
+        self.handler.finish.assert_called_with(
+            '{"error": null, "id": 1, "result": "value"}')

--- a/cyclone/tests/test_jsonrpc.py
+++ b/cyclone/tests/test_jsonrpc.py
@@ -32,5 +32,8 @@ class TestJsonrpcRequestHandler(unittest.TestCase):
         self.handler.jsonrpc_foo = lambda: "value"
         self.handler.request.body = '{"id":1, "method":"foo"}'
         self.handler.post()
-        self.handler.finish.assert_called_with(
-            json.dumps({"error": None, "id": 1, "result": "value"}))
+        arg = self.handler.finish.call_args[0][0]
+        self.assertEqual(
+            json.loads(arg),
+            {"error": None, "id": 1, "result": "value"}
+        )

--- a/cyclone/tests/test_jsonrpc.py
+++ b/cyclone/tests/test_jsonrpc.py
@@ -17,6 +17,7 @@ from twisted.trial import unittest
 from mock import Mock
 from cyclone.jsonrpc import JsonrpcRequestHandler
 from cyclone.web import Application
+import json
 
 
 class TestJsonrpcRequestHandler(unittest.TestCase):
@@ -32,4 +33,4 @@ class TestJsonrpcRequestHandler(unittest.TestCase):
         self.handler.request.body = '{"id":1, "method":"foo"}'
         self.handler.post()
         self.handler.finish.assert_called_with(
-            '{"error": null, "id": 1, "result": "value"}')
+            json.dumps({"error": None, "id": 1, "result": "value"}))

--- a/cyclone/tests/test_requirements.txt
+++ b/cyclone/tests/test_requirements.txt
@@ -1,2 +1,3 @@
 mock
 twisted>=12.0
+pyopenssl


### PR DESCRIPTION
This also includes some basic tests for the jsonrpc handler.

Note https://github.com/fiorix/cyclone/issues/133 for previous discussion.
