### PR TITLE
READY FOR REVIEW - Fix #169. Set correct Content-Type for JSON-RPC responses.

### DIFF
--- a/cyclone/jsonrpc.py
+++ b/cyclone/jsonrpc.py
@@ -75,6 +75,9 @@ class JsonrpcRequestHandler(RequestHandler):
             self._cbResult(AttributeError("method not found: %s" % method),
                            jsonid)
 
+    def set_default_headers(self):
+        self.set_header('Content-Type', 'application/json; charset=UTF-8')
+
     def _cbResult(self, result, jsonid):
         if isinstance(result, failure.Failure):
             error = {'code': 0, 'message': str(result.value)}

--- a/cyclone/web.py
+++ b/cyclone/web.py
@@ -868,6 +868,7 @@ class RequestHandler(object):
                 self.write(line)
             self.finish()
         else:
+            self.set_header('Content-Type', 'text/html; charset=UTF-8')
             self.finish("<html><title>%(code)d: %(message)s</title>"
                         "<body>%(code)d: %(message)s</body></html>" %
                         {"code": status_code, "message": self._reason})


### PR DESCRIPTION
Fix #169. Set correct `Content-Type` for JSON-RPC responses.

I don't see an existing test harness for `JsonrpcRequestHandler` or `RequestHandler`, otherwise I would have included unit tests. However, it does appear to work when I test it by hand (both with normal and error responses):

```sh
% curl --verbose -H 'Content-Type: application/json' -H 'Accept: application/json' -X POST --data [JSONRPC_DATA] [JSONRPC_URL]
...
< Content-Type: application/json; charset=UTF-8
...
```