### PR TITLE
Implement unit testing by means of Tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,15 @@ matrix:
       python: "pypy3"
     - env: TOXENV=pypy3-twisted15
       python: "pypy3"
+  allow_failures:
+    - env: TOXENV=py35-twisted12
+    - env: TOXENV=py35-twisted13
+    - env: TOXENV=py35-twisted14
+    - env: TOXENV=py35-twisted15
+    - env: TOXENV=pypy3-twisted12
+    - env: TOXENV=pypy3-twisted13
+    - env: TOXENV=pypy3-twisted14
+    - env: TOXENV=pypy3-twisted15
 
 install:
     - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,14 @@ matrix:
       python: "2.7"
     - env: TOXENV=py27-twisted15
       python: "2.7"
+    - env: TOXENV=py35-twisted12
+      python: "3.5"
+    - env: TOXENV=py35-twisted13
+      python: "3.5"
+    - env: TOXENV=py35-twisted14
+      python: "3.5"
+    - env: TOXENV=py35-twisted15
+      python: "3.5"
     - env: TOXENV=pypy-twisted12
       python: "pypy"
     - env: TOXENV=pypy-twisted13
@@ -29,11 +37,16 @@ matrix:
       python: "pypy"
     - env: TOXENV=pypy-twisted15
       python: "pypy"
-
+    - env: TOXENV=pypy3-twisted12
+      python: "pypy3"
+    - env: TOXENV=pypy3-twisted13
+      python: "pypy3"
+    - env: TOXENV=pypy3-twisted14
+      python: "pypy3"
+    - env: TOXENV=pypy3-twisted15
+      python: "pypy3"
 
 install:
-    - pip install tox coveralls
+    - pip install tox
 
 script: tox
-
-after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,6 @@ matrix:
       python: "2.7"
     - env: TOXENV=py27-twisted15
       python: "2.7"
-    - env: TOXENV=py35-twisted12
-      python: "3.5"
-    - env: TOXENV=py35-twisted13
-      python: "3.5"
-    - env: TOXENV=py35-twisted14
-      python: "3.5"
     - env: TOXENV=py35-twisted15
       python: "3.5"
     - env: TOXENV=pypy-twisted12
@@ -37,22 +31,10 @@ matrix:
       python: "pypy"
     - env: TOXENV=pypy-twisted15
       python: "pypy"
-    - env: TOXENV=pypy3-twisted12
-      python: "pypy3"
-    - env: TOXENV=pypy3-twisted13
-      python: "pypy3"
-    - env: TOXENV=pypy3-twisted14
-      python: "pypy3"
     - env: TOXENV=pypy3-twisted15
       python: "pypy3"
   allow_failures:
-    - env: TOXENV=py35-twisted12
-    - env: TOXENV=py35-twisted13
-    - env: TOXENV=py35-twisted14
     - env: TOXENV=py35-twisted15
-    - env: TOXENV=pypy3-twisted12
-    - env: TOXENV=pypy3-twisted13
-    - env: TOXENV=pypy3-twisted14
     - env: TOXENV=pypy3-twisted15
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,39 @@
 language: python
-python:
-    - "2.6"
-    - "2.7"
-    - "pypy"
+sudo: false
+
+matrix:
+  include:
+    - env: TOXENV=coveralls
+      python: "2.7"
+    - env: TOXENV=py26-twisted12
+      python: "2.6"
+    - env: TOXENV=py26-twisted13
+      python: "2.6"
+    - env: TOXENV=py26-twisted14
+      python: "2.6"
+    - env: TOXENV=py26-twisted15
+      python: "2.6"
+    - env: TOXENV=py27-twisted12
+      python: "2.7"
+    - env: TOXENV=py27-twisted13
+      python: "2.7"
+    - env: TOXENV=py27-twisted14
+      python: "2.7"
+    - env: TOXENV=py27-twisted15
+      python: "2.7"
+    - env: TOXENV=pypy-twisted12
+      python: "pypy"
+    - env: TOXENV=pypy-twisted13
+      python: "pypy"
+    - env: TOXENV=pypy-twisted14
+      python: "pypy"
+    - env: TOXENV=pypy-twisted15
+      python: "pypy"
+
 
 install:
-    - pip install -r cyclone/tests/test_requirements.txt
-    - pip install coveralls
+    - pip install tox coveralls
 
-script: coverage run `which trial` cyclone
+script: tox
+
 after_success: coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Cyclone
 =======
+[![Build Status](https://secure.travis-ci.org/fiorix/cyclone.png?branch=master)](https://travis-ci.org/fiorix/cyclone) [![Coverage Status](https://coveralls.io/repos/evilaliv3/cyclone/badge.svg?branch=tox)](https://coveralls.io/r/evilaliv3/cyclone?branch=tos)
+
 Cyclone is a web server framework for Python, that implements the Tornado API
 as a Twisted protocol.
 

--- a/cyclone/tests/test_utils.py
+++ b/cyclone/tests/test_utils.py
@@ -149,7 +149,7 @@ class UtilsTest(unittest.TestCase):
     def test_import_object(self):
         import os.path
         other_os = import_object("os.path")
-        self.assertIs(os.path, other_os)
+        self.assertIdentical(os.path, other_os)
 
     def test_import_object_fail(self):
         self.assertRaises(ImportError, import_object, "meowkittens.something")

--- a/cyclone/tests/test_web.py
+++ b/cyclone/tests/test_web.py
@@ -196,12 +196,8 @@ class RequestHandlerTest(unittest.TestCase):
         self.rh.set_cookie("name", "value", expires_days=5, max_age=55)
         expires = self.rh._new_cookie["name"]['expires']
         self.assertTrue(
-            expires >
-            email.utils.formatdate(
-                calendar.timegm(time.gmtime()),
-                localtime=False,
-                usegmt=True
-            )
+            email.utils.parsedate(expires) >
+            time.gmtime(),
         )
 
     def test_clear_cookie(self):

--- a/tox.ini
+++ b/tox.ini
@@ -11,17 +11,11 @@ envlist =
     py27-twisted13
     py27-twisted14
     py27-twisted15
-    py35-twisted12
-    py35-twisted13
-    py35-twisted14
     py35-twisted15
     pypy-twisted12
     pypy-twisted13
     pypy-twisted14
     pypy-twisted15
-    pypy3-twisted12
-    pypy3-twisted13
-    pypy3-twisted14
     pypy3-twisted15
 
 [testenv]
@@ -137,24 +131,6 @@ deps =
     coverage
     mock
     twisted>=15.0, <16.0
-
-[testenv:pypy3-twisted12]
-deps =
-    coverage
-    mock
-    twisted>=12.0, <13.0
-
-[testenv:pypy3-twisted13]
-deps =
-    coverage
-    mock
-    twisted>=13.0, <14.0
-
-[testenv:pypy3-twisted14]
-deps =
-    coverage
-    mock
-    twisted>=14.0, <15.0
 
 [testenv:pypy3-twisted15]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -11,10 +11,18 @@ envlist =
     py27-twisted13
     py27-twisted14
     py27-twisted15
+    py35-twisted12
+    py35-twisted13
+    py35-twisted14
+    py35-twisted15
     pypy-twisted12
     pypy-twisted13
     pypy-twisted14
     pypy-twisted15
+    pypy3-twisted12
+    pypy3-twisted13
+    pypy3-twisted14
+    pypy3-twisted15
 
 [testenv]
 commands =
@@ -82,6 +90,30 @@ deps =
     mock
     twisted>=15.0, <16.0
 
+[testenv:py35-twisted12]
+deps =
+    coverage
+    mock
+    twisted>=12.0, <13.0
+
+[testenv:py35-twisted13]
+deps =
+    coverage
+    mock
+    twisted>=13.0, <14.0
+
+[testenv:py35-twisted14]
+deps =
+    coverage
+    mock
+    twisted>=14.0, <15.0
+
+[testenv:py35-twisted15]
+deps =
+    coverage
+    mock
+    twisted>=15.0, <16.0
+
 [testenv:pypy-twisted12]
 deps =
     coverage
@@ -101,6 +133,30 @@ deps =
     twisted>=14.0, <15.0
 
 [testenv:pypy-twisted15]
+deps =
+    coverage
+    mock
+    twisted>=15.0, <16.0
+
+[testenv:pypy3-twisted12]
+deps =
+    coverage
+    mock
+    twisted>=12.0, <13.0
+
+[testenv:pypy3-twisted13]
+deps =
+    coverage
+    mock
+    twisted>=13.0, <14.0
+
+[testenv:pypy3-twisted14]
+deps =
+    coverage
+    mock
+    twisted>=14.0, <15.0
+
+[testenv:pypy3-twisted15]
 deps =
     coverage
     mock

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ commands =
     coverage report -m
 
 [testenv:coveralls]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
     coverage
     coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,107 @@
+; tox configuration file for running tests similar to buildbot builders.
+
+[tox]
+envlist =
+    coveralls
+    py26-twisted12
+    py26-twisted13
+    py26-twisted14
+    py26-twisted15
+    py27-twisted12
+    py27-twisted13
+    py27-twisted14
+    py27-twisted15
+    pypy-twisted12
+    pypy-twisted13
+    pypy-twisted14
+    pypy-twisted15
+
+[testenv]
+commands =
+    coverage erase
+    coverage run --source=./cyclone {envbindir}/trial --rterrors {posargs:cyclone}
+    coverage report -m
+
+[testenv:coveralls]
+deps =
+    coverage
+    coveralls
+    mock
+    twisted>=15.0, <16.0
+commands =
+    coverage erase
+    coverage run --source=./cyclone {envbindir}/trial --rterrors {posargs:cyclone}
+    coverage report -m
+    coveralls
+
+[testenv:py26-twisted12]
+deps =
+    coverage
+    mock
+    twisted>=12.0, <13.0
+
+[testenv:py26-twisted13]
+deps =
+    coverage
+    mock
+    twisted>=13.0, <14.0
+
+[testenv:py26-twisted14]
+deps =
+    coverage
+    mock
+    twisted>=14.0, <15.0
+
+[testenv:py26-twisted15]
+deps =
+    coverage
+    mock
+    twisted>=15.0, <15.5
+
+[testenv:py27-twisted12]
+deps =
+    coverage
+    mock
+    twisted>=12.0, <13.0
+
+[testenv:py27-twisted13]
+deps =
+    coverage
+    mock
+    twisted>=13.0, <14.0
+
+[testenv:py27-twisted14]
+deps =
+    coverage
+    mock
+    twisted>=14.0, <15.0
+
+[testenv:py27-twisted15]
+deps =
+    coverage
+    mock
+    twisted>=15.0, <16.0
+
+[testenv:pypy-twisted12]
+deps =
+    coverage
+    mock
+    twisted>=12.0, <13.0
+
+[testenv:pypy-twisted13]
+deps =
+    coverage
+    mock
+    twisted>=13.0, <14.0
+
+[testenv:pypy-twisted14]
+deps =
+    coverage
+    mock
+    twisted>=14.0, <15.0
+
+[testenv:pypy-twisted15]
+deps =
+    coverage
+    mock
+    twisted>=15.0, <16.0


### PR DESCRIPTION
With this commit i've switched unit-tests to use [Tox](https://tox.readthedocs.org/en/latest/)

This way we could start testing properly against the different versions of python (at least 2.7 and 3.5) as for ticket https://github.com/fiorix/cyclone/issues/171

With this pull request:
- tests are performed on python 2.6, 2.7, 3.5, pypy, pypy3
- tests are performed on twisted 12, 13, 14, 15
- i've fixed a test to be compatible with twisted 12
- tests for python 3.5 and pypy3 are currently allowed to fail in order to not impact the success badge
- unit tests are now using travis container-based infrastructure that should benefit of being a little more fast
