### PR TITLE
Fix bytes/string issue when using chunked transfer encoding

### DIFF
--- a/cyclone/web.py
+++ b/cyclone/web.py
@@ -1921,9 +1921,9 @@ class ChunkedTransferEncoding(OutputTransform):
             # Don't write out empty chunks because that means END-OF-STREAM
             # with chunked encoding
             if block:
-                block = "%s\r\n%s\r\n" % (utf8("%x" % len(block)), block)
+                block = b"%s\r\n%s\r\n" % (b"%x" % len(block), block)
             if finishing:
-                block = "%s0\r\n\r\n" % block
+                block = b"%s0\r\n\r\n" % block
         return block
 
 


### PR DESCRIPTION
When chunked transfer encoding is used (the default behavior for responses to HTTP 1.1 requests) an exception gets raised because `transform_chunk` returns an str, which then gets appended to `headers` in `flush`, which is a bytestring, so you get a traceback like this:
```
  File "/home/marcus/......../twisted/internet/defer.py", line 654, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/home/marcus/src/cyclone/cyclone/web.py", line 1159, in _execute_failure
    return self._handle_request_exception(err)
  File "/home/marcus/src/cyclone/cyclone/web.py", line 1211, in _handle_request_exception
    self.send_error(500, exception=e)
  File "/home/marcus/src/cyclone/cyclone/web.py", line 766, in send_error
    self.finish()
  File "/home/marcus/src/cyclone/cyclone/web.py", line 746, in finish
    self.flush(include_footers=True)
  File "/home/marcus/src/cyclone/cyclone/web.py", line 708, in flush
    self.request.write(headers + chunk)
builtins.TypeError: can't concat str to bytes
```

There was also another bug where `ChunkedTransferEncoding.transform_chunk` would include `b'` prefixes on the chunk size and chunk contents.