### PR TITLE
[Chore] Update Twsited / pyopenssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: python
 
-# because python3.7 is not available on trusty
-# @see https://github.com/travis-ci/travis-ci/issues/9815
-dist: xenial 
+dist: focal
 
-# Test on python3
 python:
-  - 3.5 # debian
-  - 3.6 # ubuntu / amazonlinux
-  - 3.7 # fedora
+  - 3.7
+  - 3.8
+  - 3.9
+  - 3.10
+  - 3.11
   - nightly
 
 # Allow failures on cpython nightly build
@@ -29,7 +28,7 @@ script: coverage run `which trial` cyclone
 after_success: coveralls
 
 # deploy on pypi
-# only on 3.6 (avoid multiple deployment)
+# only on 3.7 (avoid multiple deployment)
 deploy:
   provider: pypi
   user: fiorix
@@ -38,5 +37,5 @@ deploy:
   on:
     tags: true
     branch: master
-    condition: $TRAVIS_PYTHON_VERSION = 3.6
+    condition: $TRAVIS_PYTHON_VERSION = 3.7
   distributions: "sdist bdist_wheel"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - 3.8
   - 3.9
   - 3.10
-  - 3.11
+  - 3.11-dev
   - nightly
 
 # Allow failures on cpython nightly build

--- a/README.md
+++ b/README.md
@@ -33,12 +33,7 @@ The Cyclone source code is hosted on GitHub: https://github.com/fiorix/cyclone
 Prerequisites
 -------------
 
-Cyclone runs on Python 2.5, 2.6 and 2.7, and requires:
-
-- Twisted: http://twistedmatrix.com/trac/wiki/Downloads
-- pyOpenSSL: https://launchpad.net/pyopenssl (only if you want SSL/TLS)
-
-On Python 2.5, simplejson is required too.
+Cyclone requires python 3.7 (or greather) 
 
 Platforms
 ---------

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setuptools.setup(
                   "cyclone": ["appskel_default.zip",
                               "appskel_foreman.zip",
                               "appskel_signup.zip"]},
+    python_requires=">=3.7",
     scripts=["scripts/cyclone"],
     install_requires=["twisted==22.8.0","pyOpenSSL==22.0.0"],
     classifiers=CLASSIFIERS,

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,6 @@ setuptools.setup(
                               "appskel_foreman.zip",
                               "appskel_signup.zip"]},
     scripts=["scripts/cyclone"],
-    install_requires=["twisted==19.2.1","pyOpenSSL==19.0.0"],
+    install_requires=["twisted==22.8.*","pyOpenSSL==22.0.*"],
     classifiers=CLASSIFIERS,
 )

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,6 @@ setuptools.setup(
                               "appskel_foreman.zip",
                               "appskel_signup.zip"]},
     scripts=["scripts/cyclone"],
-    install_requires=["twisted==22.8.*","pyOpenSSL==22.0.*"],
+    install_requires=["twisted==22.8.0","pyOpenSSL==22.0.0"],
     classifiers=CLASSIFIERS,
 )


### PR DESCRIPTION
This `PR` updates some dependencies.

+ [x] Twisted, is upgraded from `19.2.1` to `22.8.0`, more details at https://github.com/twisted/twisted/blob/HEAD/NEWS.rst
+ [x] PyOpenSSL, is upgrade from `19.0.0` to `22.0.0`, more details at https://github.com/pyca/pyopenssl/blob/main/CHANGELOG.rst

#### Required changes :

+ Python 3.10 and 3.11 could be supported
+ Python 3.6 is no longer supported